### PR TITLE
Sync watch db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@
 vendor/*
 
 # Mocks
-mocks/*
+**/mock*.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,9 @@ RUN mv dep /usr/bin/
 RUN dep ensure
 RUN GOBIN=$PWD/vendor/bin/ go install ./vendor/github.com/golang/mock/mockgen/
 
-RUN mkdir mocks
 RUN vendor/bin/mockgen -destination=mocks/mock_kinesis_queue/mock_kinesis_queue.go github.com/kine-dmd/api/kinesisqueue KinesisQueueInterface
 RUN vendor/bin/mockgen -destination=mocks/mock_dynamo_db/mock_dynamo_db.go github.com/kine-dmd/api/dynamoDB DynamoDBInterface
-RUN vendor/bin/mockgen -destination=mocks/mock_time/mock_time.go github.com/kine-dmd/api/api_time ApiTime
+RUN vendor/bin/mockgen -destination=api_time/mock_time.go -package=api_time github.com/kine-dmd/api/api_time ApiTime
 RUN vendor/bin/mockgen -destination=mocks/mock_watch_pos_db/mock_watch_pos_db.go github.com/kine-dmd/api/watch_position_db WatchPositionDatabase
 RUN vendor/bin/mockgen -destination=watch_position_db/mock_watch_pos_db.go  -package=watch_position_db github.com/kine-dmd/api/watch_position_db WatchPositionDatabase
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,12 @@ RUN mkdir mocks
 RUN vendor/bin/mockgen -destination=mocks/mock_kinesis_queue/mock_kinesis_queue.go github.com/kine-dmd/api/kinesisqueue KinesisQueueInterface
 RUN vendor/bin/mockgen -destination=mocks/mock_dynamo_db/mock_dynamo_db.go github.com/kine-dmd/api/dynamoDB DynamoDBInterface
 RUN vendor/bin/mockgen -destination=mocks/mock_time/mock_time.go github.com/kine-dmd/api/api_time ApiTime
-RUN vendor/bin/mockgen -destination=mocks/mock_watch_pos_db/mock_watch_pos_db.go github.com/kine-dmd/api/watch_position_db WatchPositionDB
+RUN vendor/bin/mockgen -destination=mocks/mock_watch_pos_db/mock_watch_pos_db.go github.com/kine-dmd/api/watch_position_db WatchPositionDatabase
+RUN vendor/bin/mockgen -destination=watch_position_db/mock_watch_pos_db.go  -package=watch_position_db github.com/kine-dmd/api/watch_position_db WatchPositionDatabase
 
 RUN go test -v ./...
 
-RUN rm -f **/*_test.go && rm -rf vendor/bin && rm -rf mocks
+RUN rm -f **/*_test.go && rm -rf vendor/bin && rm -rf mocks && rm watch_position_db/mock_watch_pos_db.go
 
 RUN go build -o ~/go/bin/main .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.11.2-alpine3.8
 WORKDIR /go/src/github.com/kine-dmd/api/
 
 COPY . .
-RUN rm -rf vendor/ && rm -rf mocks && rm -f **/mock*.go
+RUN rm -rf vendor/ && rm -f **/mock*.go
 
 EXPOSE 80
 
@@ -21,14 +21,13 @@ RUN dep ensure
 RUN GOBIN=$PWD/vendor/bin/ go install ./vendor/github.com/golang/mock/mockgen/
 
 RUN vendor/bin/mockgen -destination=kinesisqueue/mock_kinesis_queue.go -package=kinesisqueue github.com/kine-dmd/api/kinesisqueue KinesisQueueInterface
-RUN vendor/bin/mockgen -destination=mocks/mock_dynamo_db/mock_dynamo_db.go github.com/kine-dmd/api/dynamoDB DynamoDBInterface
+RUN vendor/bin/mockgen -destination=dynamoDB/mock_dynamo_db.go -package=dynamoDB github.com/kine-dmd/api/dynamoDB DynamoDBInterface
 RUN vendor/bin/mockgen -destination=api_time/mock_time.go -package=api_time github.com/kine-dmd/api/api_time ApiTime
-RUN vendor/bin/mockgen -destination=mocks/mock_watch_pos_db/mock_watch_pos_db.go github.com/kine-dmd/api/watch_position_db WatchPositionDatabase
 RUN vendor/bin/mockgen -destination=watch_position_db/mock_watch_pos_db.go  -package=watch_position_db github.com/kine-dmd/api/watch_position_db WatchPositionDatabase
 
 RUN go test -v ./...
 
-RUN rm -f **/*_test.go && rm -rf vendor/bin && rm -rf mocks && rm -f **/mock*.go
+RUN rm -f **/*_test.go && rm -rf vendor/bin && rm -f **/mock*.go
 
 RUN go build -o ~/go/bin/main .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.11.2-alpine3.8
 WORKDIR /go/src/github.com/kine-dmd/api/
 
 COPY . .
-RUN rm -rf vendor/ && rm -rf mocks
+RUN rm -rf vendor/ && rm -rf mocks && rm -f **/mock*.go
 
 EXPOSE 80
 
@@ -20,7 +20,7 @@ RUN mv dep /usr/bin/
 RUN dep ensure
 RUN GOBIN=$PWD/vendor/bin/ go install ./vendor/github.com/golang/mock/mockgen/
 
-RUN vendor/bin/mockgen -destination=mocks/mock_kinesis_queue/mock_kinesis_queue.go github.com/kine-dmd/api/kinesisqueue KinesisQueueInterface
+RUN vendor/bin/mockgen -destination=kinesisqueue/mock_kinesis_queue.go -package=kinesisqueue github.com/kine-dmd/api/kinesisqueue KinesisQueueInterface
 RUN vendor/bin/mockgen -destination=mocks/mock_dynamo_db/mock_dynamo_db.go github.com/kine-dmd/api/dynamoDB DynamoDBInterface
 RUN vendor/bin/mockgen -destination=api_time/mock_time.go -package=api_time github.com/kine-dmd/api/api_time ApiTime
 RUN vendor/bin/mockgen -destination=mocks/mock_watch_pos_db/mock_watch_pos_db.go github.com/kine-dmd/api/watch_position_db WatchPositionDatabase
@@ -28,7 +28,7 @@ RUN vendor/bin/mockgen -destination=watch_position_db/mock_watch_pos_db.go  -pac
 
 RUN go test -v ./...
 
-RUN rm -f **/*_test.go && rm -rf vendor/bin && rm -rf mocks && rm watch_position_db/mock_watch_pos_db.go
+RUN rm -f **/*_test.go && rm -rf vendor/bin && rm -rf mocks && rm -f **/mock*.go
 
 RUN go build -o ~/go/bin/main .
 

--- a/apple_watch_3/apple_watch_3.go
+++ b/apple_watch_3/apple_watch_3.go
@@ -17,7 +17,7 @@ type unparsedAppleWatch3Data struct {
 
 type apple_watch_3_handler struct {
 	queue   kinesisqueue.KinesisQueueInterface
-	watchDB watch_position_db.WatchPositionDB
+	watchDB watch_position_db.WatchPositionDatabase
 }
 
 func MakeStandardAppleWatch3Handler(r *mux.Router) *apple_watch_3_handler {
@@ -29,7 +29,7 @@ func MakeStandardAppleWatch3Handler(r *mux.Router) *apple_watch_3_handler {
 	return MakeAppleWatch3Handler(r, queue, watchDB)
 }
 
-func MakeAppleWatch3Handler(r *mux.Router, queue kinesisqueue.KinesisQueueInterface, watchDB watch_position_db.WatchPositionDB) *apple_watch_3_handler {
+func MakeAppleWatch3Handler(r *mux.Router, queue kinesisqueue.KinesisQueueInterface, watchDB watch_position_db.WatchPositionDatabase) *apple_watch_3_handler {
 	// Assign the databases
 	aw3Handler := new(apple_watch_3_handler)
 	aw3Handler.queue = queue

--- a/apple_watch_3/apple_watch_3_test.go
+++ b/apple_watch_3/apple_watch_3_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	"github.com/kine-dmd/api/kinesisqueue"
-	"github.com/kine-dmd/api/mocks/mock_watch_pos_db"
 	"github.com/kine-dmd/api/watch_position_db"
 	"net/http"
 	"net/http/httptest"
@@ -112,11 +111,11 @@ func TestValidUUID(t *testing.T) {
 	mockCtrl.Finish()
 }
 
-func makeMockQueueAndDB(t *testing.T) (*gomock.Controller, *kinesisqueue.MockKinesisQueueInterface, *mock_watch_position_db.MockWatchPositionDatabase) {
+func makeMockQueueAndDB(t *testing.T) (*gomock.Controller, *kinesisqueue.MockKinesisQueueInterface, *watch_position_db.MockWatchPositionDatabase) {
 	// Make a mock for the kinesis queue
 	mockCtrl := gomock.NewController(t)
 	mockQueue := kinesisqueue.NewMockKinesisQueueInterface(mockCtrl)
-	mockDB := mock_watch_position_db.NewMockWatchPositionDatabase(mockCtrl)
+	mockDB := watch_position_db.NewMockWatchPositionDatabase(mockCtrl)
 	return mockCtrl, mockQueue, mockDB
 }
 

--- a/apple_watch_3/apple_watch_3_test.go
+++ b/apple_watch_3/apple_watch_3_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	"github.com/kine-dmd/api/kinesisqueue"
-	"github.com/kine-dmd/api/mocks/mock_kinesis_queue"
 	"github.com/kine-dmd/api/mocks/mock_watch_pos_db"
 	"github.com/kine-dmd/api/watch_position_db"
 	"net/http"
@@ -113,10 +112,10 @@ func TestValidUUID(t *testing.T) {
 	mockCtrl.Finish()
 }
 
-func makeMockQueueAndDB(t *testing.T) (*gomock.Controller, *mock_kinesisqueue.MockKinesisQueueInterface, *mock_watch_position_db.MockWatchPositionDatabase) {
+func makeMockQueueAndDB(t *testing.T) (*gomock.Controller, *kinesisqueue.MockKinesisQueueInterface, *mock_watch_position_db.MockWatchPositionDatabase) {
 	// Make a mock for the kinesis queue
 	mockCtrl := gomock.NewController(t)
-	mockQueue := mock_kinesisqueue.NewMockKinesisQueueInterface(mockCtrl)
+	mockQueue := kinesisqueue.NewMockKinesisQueueInterface(mockCtrl)
 	mockDB := mock_watch_position_db.NewMockWatchPositionDatabase(mockCtrl)
 	return mockCtrl, mockQueue, mockDB
 }

--- a/apple_watch_3/apple_watch_3_test.go
+++ b/apple_watch_3/apple_watch_3_test.go
@@ -113,15 +113,15 @@ func TestValidUUID(t *testing.T) {
 	mockCtrl.Finish()
 }
 
-func makeMockQueueAndDB(t *testing.T) (*gomock.Controller, *mock_kinesisqueue.MockKinesisQueueInterface, *mock_watch_position_db.MockWatchPositionDB) {
+func makeMockQueueAndDB(t *testing.T) (*gomock.Controller, *mock_kinesisqueue.MockKinesisQueueInterface, *mock_watch_position_db.MockWatchPositionDatabase) {
 	// Make a mock for the kinesis queue
 	mockCtrl := gomock.NewController(t)
 	mockQueue := mock_kinesisqueue.NewMockKinesisQueueInterface(mockCtrl)
-	mockDB := mock_watch_position_db.NewMockWatchPositionDB(mockCtrl)
+	mockDB := mock_watch_position_db.NewMockWatchPositionDatabase(mockCtrl)
 	return mockCtrl, mockQueue, mockDB
 }
 
-func initRouterAndHandler(mockQueue kinesisqueue.KinesisQueueInterface, mockWatchDB watch_position_db.WatchPositionDB) (*mux.Router, *apple_watch_3_handler) {
+func initRouterAndHandler(mockQueue kinesisqueue.KinesisQueueInterface, mockWatchDB watch_position_db.WatchPositionDatabase) (*mux.Router, *apple_watch_3_handler) {
 	router := mux.NewRouter()
 	handler := MakeAppleWatch3Handler(router, mockQueue, mockWatchDB)
 	return router, handler

--- a/watch_position_db/cached_wp_db.go
+++ b/watch_position_db/cached_wp_db.go
@@ -1,0 +1,93 @@
+package watch_position_db
+
+import (
+	"github.com/kine-dmd/api/api_time"
+	"sync"
+	"time"
+)
+
+// An in memory cache of a UUID -> watch position database
+type dynamoCachedWatchDB struct {
+	dbConnection  WatchPositionDatabase
+	cache         map[string]WatchPosition
+	cacheMutex    sync.RWMutex
+	lastUpdatedAt time.Time
+	timeMutex     sync.RWMutex
+	timeKeeper    api_time.ApiTime
+}
+
+func MakeStandardDynamoCachedWatchDB() *dynamoCachedWatchDB {
+	// Use a dynamo database and the standard system time
+	return MakeCachedWatchDB(makeStandardDynamoWatchDatabase(), api_time.SystemTime{})
+}
+
+func MakeCachedWatchDB(dbConnection WatchPositionDatabase, timeKeeper api_time.ApiTime) *dynamoCachedWatchDB {
+	// Create a new connection
+	dcw := new(dynamoCachedWatchDB)
+	dcw.dbConnection = dbConnection
+	dcw.timeKeeper = timeKeeper
+
+	// Eager load the cache
+	dcw.cacheMutex = sync.RWMutex{}
+	dcw.timeMutex = sync.RWMutex{}
+	dcw.updateCache()
+	return dcw
+}
+
+func (dcw *dynamoCachedWatchDB) GetWatchPosition(uuid string) (WatchPosition, bool) {
+	// If it had been more than 2 hours, always update the cache
+	if dcw.shouldUpdateCache() {
+		dcw.updateCache()
+	}
+
+	// Obtain a read lock for the cache
+	defer dcw.cacheMutex.RUnlock()
+	dcw.cacheMutex.RLock()
+
+	// Return value and whether it exists or not
+	val, ok := dcw.cache[uuid]
+	return val, ok
+}
+
+func (dcw *dynamoCachedWatchDB) GetTableScan() map[string]WatchPosition {
+	// If it had been more than 2 hours, always update the cache
+	if dcw.shouldUpdateCache() {
+		dcw.updateCache()
+	}
+
+	// Obtain a read lock for the cache
+	defer dcw.cacheMutex.RUnlock()
+	dcw.cacheMutex.RLock()
+
+	// Return value and whether it exists or not
+	return dcw.cache
+}
+
+func (dcw *dynamoCachedWatchDB) shouldUpdateCache() bool {
+	// Get a read lock for the time
+	defer dcw.timeMutex.RUnlock()
+	dcw.timeMutex.RLock()
+
+	// If it had been more than 2 hours update the cache
+	durationSinceUpdate := dcw.timeKeeper.CurrentTime().Sub(dcw.lastUpdatedAt)
+	return durationSinceUpdate.Hours() >= 2
+}
+
+func (dcw *dynamoCachedWatchDB) updateCache() {
+	// Get the timestamp for the cache
+	defer dcw.cacheMutex.Unlock()
+	dcw.cacheMutex.Lock()
+
+	// Check someone else has not already updated the cache while we waited
+	if !dcw.shouldUpdateCache() {
+		return
+	}
+
+	// Get the write lock for the timestamp
+	defer dcw.timeMutex.Unlock()
+	dcw.timeMutex.Lock()
+
+	// Update the cached values
+	dcw.cache = dcw.dbConnection.GetTableScan()
+	dcw.lastUpdatedAt = dcw.timeKeeper.CurrentTime()
+}

--- a/watch_position_db/cached_wp_db_test.go
+++ b/watch_position_db/cached_wp_db_test.go
@@ -2,7 +2,6 @@ package watch_position_db
 
 import (
 	"github.com/golang/mock/gomock"
-	"github.com/kine-dmd/api/mocks/mock_dynamo_db"
 	"github.com/kine-dmd/api/mocks/mock_time"
 	"sync"
 	"testing"
@@ -16,7 +15,7 @@ func TestGetsDataOnCreation(t *testing.T) {
 	mockTime.EXPECT().CurrentTime().Return(time.Now()).Times(2)
 
 	// Make an empty cached DB and query it
-	_ = MakeDynamoCachedWatchDB(mockDB, mockTime)
+	_ = MakeCachedWatchDB(mockDB, mockTime)
 	mockCtrl.Finish()
 }
 
@@ -28,7 +27,7 @@ func TestRetrievingRowFromCache(t *testing.T) {
 	mockTime.EXPECT().CurrentTime().Return(curTime).Times(2)
 
 	// Make an empty cached DB and query it
-	dcw := MakeDynamoCachedWatchDB(mockDB, mockTime)
+	dcw := MakeCachedWatchDB(mockDB, mockTime)
 	mockTime.EXPECT().CurrentTime().Return(curTime.Add(time.Hour)).Times(1)
 	watchPos, exists := dcw.GetWatchPosition("00000000-0000-0000-0000-000000000001")
 
@@ -41,12 +40,12 @@ func TestRetrievingRowFromCache(t *testing.T) {
 func TestRetrievingRowReloadCache(t *testing.T) {
 	// Make mocks and set the expectations
 	mockCtrl, mockDB, mockTime := makeMocks(t)
-	mockDB.EXPECT().GetTableScan().Return(makeFakeData()).Times(1)
 
 	// Make an empty cached DB and query it
 	curTime := time.Now()
 	mockTime.EXPECT().CurrentTime().Return(curTime).Times(2)
-	dcw := MakeDynamoCachedWatchDB(mockDB, mockTime)
+	mockDB.EXPECT().GetTableScan().Return(makeFakeData()).Times(1)
+	dcw := MakeCachedWatchDB(mockDB, mockTime)
 
 	// Query the data 3 hours after load
 	mockTime.EXPECT().CurrentTime().Return(curTime.Add(time.Hour * 3)).Times(3)
@@ -67,7 +66,7 @@ func TestRetrievingRowReloadCacheThenFromCache(t *testing.T) {
 	// Make an empty cached DB and query it
 	curTime := time.Now()
 	mockTime.EXPECT().CurrentTime().Return(curTime).Times(2)
-	dcw := MakeDynamoCachedWatchDB(mockDB, mockTime)
+	dcw := MakeCachedWatchDB(mockDB, mockTime)
 
 	// Query the data 3 hours after load
 	mockTime.EXPECT().CurrentTime().Return(curTime.Add(time.Hour * 3)).Times(3)
@@ -96,7 +95,7 @@ func TestStressOnlyPerformsOneReload(t *testing.T) {
 	// Make an empty cached DB and query it
 	curTime := time.Now()
 	mockTime.EXPECT().CurrentTime().Return(curTime).Times(2)
-	dcw := MakeDynamoCachedWatchDB(mockDB, mockTime)
+	dcw := MakeCachedWatchDB(mockDB, mockTime)
 
 	// Query the data 3 hours after load
 	mockTime.EXPECT().CurrentTime().Return(curTime.Add(time.Hour * 3)).AnyTimes()
@@ -140,29 +139,22 @@ func checkRetrievedWatchPositionValues(t *testing.T, position WatchPosition, lim
 	}
 }
 
-func makeFakeDataRow(uuid string, limb uint8, patientId string) map[string]interface{} {
-	return map[string]interface{}{"uuid": uuid,
-		"limb":      float64(limb),
-		"patientId": patientId,
-	}
-}
-
-func makeFakeData() []map[string]interface{} {
+func makeFakeData() map[string]WatchPosition {
 	// Make a list of all rows
-	allData := make([]map[string]interface{}, 3)
+	allData := make(map[string]WatchPosition)
 
 	// Create 3 fake rows
-	allData[0] = makeFakeDataRow("00000000-0000-0000-0000-000000000000", 1, "dmd01")
-	allData[1] = makeFakeDataRow("00000000-0000-0000-0000-000000000001", 2, "dmd01")
-	allData[2] = makeFakeDataRow("00000000-0000-0000-0000-000000000002", 1, "dmd02")
+	allData["00000000-0000-0000-0000-000000000000"] = WatchPosition{"dmd01", 1}
+	allData["00000000-0000-0000-0000-000000000001"] = WatchPosition{"dmd01", 2}
+	allData["00000000-0000-0000-0000-000000000002"] = WatchPosition{"dmd02", 1}
 
 	return allData
 }
 
-func makeMocks(t *testing.T) (*gomock.Controller, *mock_dynamoDB.MockDynamoDBInterface, *mock_api_time.MockApiTime) {
+func makeMocks(t *testing.T) (*gomock.Controller, *MockWatchPositionDatabase, *mock_api_time.MockApiTime) {
 	// Make a mock for the time and database
 	mockCtrl := gomock.NewController(t)
-	mockDB := mock_dynamoDB.NewMockDynamoDBInterface(mockCtrl)
+	mockDB := NewMockWatchPositionDatabase(mockCtrl)
 	mockTime := mock_api_time.NewMockApiTime(mockCtrl)
 	return mockCtrl, mockDB, mockTime
 }

--- a/watch_position_db/cached_wp_db_test.go
+++ b/watch_position_db/cached_wp_db_test.go
@@ -2,7 +2,7 @@ package watch_position_db
 
 import (
 	"github.com/golang/mock/gomock"
-	"github.com/kine-dmd/api/mocks/mock_time"
+	"github.com/kine-dmd/api/api_time"
 	"sync"
 	"testing"
 	"time"
@@ -151,10 +151,10 @@ func makeFakeData() map[string]WatchPosition {
 	return allData
 }
 
-func makeMocks(t *testing.T) (*gomock.Controller, *MockWatchPositionDatabase, *mock_api_time.MockApiTime) {
+func makeMocks(t *testing.T) (*gomock.Controller, *MockWatchPositionDatabase, *api_time.MockApiTime) {
 	// Make a mock for the time and database
 	mockCtrl := gomock.NewController(t)
 	mockDB := NewMockWatchPositionDatabase(mockCtrl)
-	mockTime := mock_api_time.NewMockApiTime(mockCtrl)
+	mockTime := api_time.NewMockApiTime(mockCtrl)
 	return mockCtrl, mockDB, mockTime
 }

--- a/watch_position_db/dynamo_watch_position_adapter.go
+++ b/watch_position_db/dynamo_watch_position_adapter.go
@@ -1,0 +1,51 @@
+package watch_position_db
+
+import (
+	"github.com/kine-dmd/api/dynamoDB"
+	"log"
+)
+
+type dynamoWatchDatabase struct {
+	dbConnection dynamoDB.DynamoDBInterface
+}
+
+func makeStandardDynamoWatchDatabase() *dynamoWatchDatabase {
+	// Connect to Dynamo
+	const table_name string = "apple_watch_3_positions"
+	dbConnection := &dynamoDB.DynamoDBClient{}
+	err := dbConnection.InitConn(table_name)
+	if err != nil {
+		log.Println("Error establishing connection to DynamoDB")
+		log.Fatal(err)
+	}
+
+	return makeDynamoWatchDatabase(dbConnection)
+}
+
+func makeDynamoWatchDatabase(dbInterface dynamoDB.DynamoDBInterface) *dynamoWatchDatabase {
+	dwb := new(dynamoWatchDatabase)
+	dwb.dbConnection = dbInterface
+	return dwb
+}
+
+func (dwb dynamoWatchDatabase) GetTableScan() map[string]WatchPosition {
+	// Get the raw data from DynamoDB
+	unparsedRows := dwb.dbConnection.GetTableScan()
+
+	// Format the data
+	var parsedRows = make(map[string]WatchPosition)
+	for _, row := range unparsedRows {
+		parsedRows[row["uuid"].(string)] = WatchPosition{
+			row["patientId"].(string),
+			uint8(row["limb"].(float64)),
+		}
+	}
+
+	return parsedRows
+}
+
+func (dwb dynamoWatchDatabase) GetWatchPosition(uuid string) (WatchPosition, bool) {
+	table := dwb.GetTableScan()
+	val, ok := table[uuid]
+	return val, ok
+}

--- a/watch_position_db/watch_position_db.go
+++ b/watch_position_db/watch_position_db.go
@@ -1,109 +1,12 @@
 package watch_position_db
 
-import (
-	"github.com/kine-dmd/api/api_time"
-	"github.com/kine-dmd/api/dynamoDB"
-	"log"
-	"sync"
-	"time"
-)
-
 type WatchPosition struct {
 	PatientID string `json:"PatientID"`
 	Limb      uint8  `json:"Limb"`
 }
 
-type WatchPositionDB interface {
+// The representation we display to others
+type WatchPositionDatabase interface {
 	GetWatchPosition(uuid string) (WatchPosition, bool)
-}
-
-type dynamoCachedWatchDB struct {
-	dbConnection  dynamoDB.DynamoDBInterface
-	cache         map[string]WatchPosition
-	cacheMutex    sync.RWMutex
-	lastUpdatedAt time.Time
-	timeMutex     sync.RWMutex
-	timeKeeper    api_time.ApiTime
-}
-
-func MakeStandardDynamoCachedWatchDB() *dynamoCachedWatchDB {
-	// Connect to Dynamo
-	const table_name string = "apple_watch_3_positions"
-	dbConnection := &dynamoDB.DynamoDBClient{}
-	err := dbConnection.InitConn(table_name)
-	if err != nil {
-		log.Println("Error establishing connection to DynamoDB")
-		log.Fatal(err)
-	}
-
-	return MakeDynamoCachedWatchDB(dbConnection, api_time.SystemTime{})
-}
-
-func MakeDynamoCachedWatchDB(dbConnection dynamoDB.DynamoDBInterface, timeKeeper api_time.ApiTime) *dynamoCachedWatchDB {
-	// Create a new connection
-	dcw := new(dynamoCachedWatchDB)
-	dcw.dbConnection = dbConnection
-	dcw.timeKeeper = timeKeeper
-
-	// Eager load the cache
-	dcw.cacheMutex = sync.RWMutex{}
-	dcw.timeMutex = sync.RWMutex{}
-	dcw.updateCache()
-	return dcw
-}
-
-func (dcw *dynamoCachedWatchDB) GetWatchPosition(uuid string) (WatchPosition, bool) {
-	// If it had been more than 2 hours, always update the cache
-	if dcw.shouldUpdateCache() {
-		dcw.updateCache()
-	}
-
-	// Obtain a read lock for the cache
-	defer dcw.cacheMutex.RUnlock()
-	dcw.cacheMutex.RLock()
-
-	// Return value and whether it exists or not
-	val, ok := dcw.cache[uuid]
-	return val, ok
-}
-
-func (dcw *dynamoCachedWatchDB) shouldUpdateCache() bool {
-	// Get a read lock for the time
-	defer dcw.timeMutex.RUnlock()
-	dcw.timeMutex.RLock()
-
-	// If it had been more than 2 hours update the cache
-	durationSinceUpdate := dcw.timeKeeper.CurrentTime().Sub(dcw.lastUpdatedAt)
-	return durationSinceUpdate.Hours() >= 2
-}
-
-func (dcw *dynamoCachedWatchDB) updateCache() {
-	// Get the timestamp for the cache
-	defer dcw.cacheMutex.Unlock()
-	dcw.cacheMutex.Lock()
-
-	// Check someone else has not already updated the cache while we waited
-	if !dcw.shouldUpdateCache() {
-		return
-	}
-
-	// Get the raw data from DynamoDB
-	unparsedRows := dcw.dbConnection.GetTableScan()
-
-	// Format the data
-	var parsedRows = make(map[string]WatchPosition)
-	for _, row := range unparsedRows {
-		parsedRows[row["uuid"].(string)] = WatchPosition{
-			row["patientId"].(string),
-			uint8(row["limb"].(float64)),
-		}
-	}
-
-	// Get the write lock for the timestamp
-	defer dcw.timeMutex.Unlock()
-	dcw.timeMutex.Lock()
-
-	// Update the cached values
-	dcw.cache = parsedRows
-	dcw.lastUpdatedAt = dcw.timeKeeper.CurrentTime()
+	GetTableScan() map[string]WatchPosition
 }

--- a/watch_position_db/watch_position_db_test.go
+++ b/watch_position_db/watch_position_db_test.go
@@ -12,7 +12,7 @@ func TestGetsDataOnCreation(t *testing.T) {
 	// Make mocks and set the expectations
 	mockCtrl, mockDB, mockTime := makeMocks(t)
 	mockDB.EXPECT().GetTableScan().Return(makeFakeData()).Times(1)
-	mockTime.EXPECT().CurrentTime().Return(time.Now()).Times(1)
+	mockTime.EXPECT().CurrentTime().Return(time.Now()).Times(2)
 
 	// Make an empty cached DB and query it
 	_ = MakeDynamoCachedWatchDB(mockDB, mockTime)
@@ -24,7 +24,7 @@ func TestRetrievingRowFromCache(t *testing.T) {
 	mockCtrl, mockDB, mockTime := makeMocks(t)
 	mockDB.EXPECT().GetTableScan().Return(makeFakeData()).Times(1)
 	curTime := time.Now()
-	mockTime.EXPECT().CurrentTime().Return(curTime).Times(1)
+	mockTime.EXPECT().CurrentTime().Return(curTime).Times(2)
 
 	// Make an empty cached DB and query it
 	dcw := MakeDynamoCachedWatchDB(mockDB, mockTime)
@@ -44,11 +44,11 @@ func TestRetrievingRowReloadCache(t *testing.T) {
 
 	// Make an empty cached DB and query it
 	curTime := time.Now()
-	mockTime.EXPECT().CurrentTime().Return(curTime).Times(1)
+	mockTime.EXPECT().CurrentTime().Return(curTime).Times(2)
 	dcw := MakeDynamoCachedWatchDB(mockDB, mockTime)
 
 	// Query the data 3 hours after load
-	mockTime.EXPECT().CurrentTime().Return(curTime.Add(time.Hour * 3)).Times(2)
+	mockTime.EXPECT().CurrentTime().Return(curTime.Add(time.Hour * 3)).Times(3)
 	mockDB.EXPECT().GetTableScan().Return(makeFakeData()).Times(1)
 	watchPos, exists := dcw.GetWatchPosition("00000000-0000-0000-0000-000000000001")
 
@@ -65,11 +65,11 @@ func TestRetrievingRowReloadCacheThenFromCache(t *testing.T) {
 
 	// Make an empty cached DB and query it
 	curTime := time.Now()
-	mockTime.EXPECT().CurrentTime().Return(curTime).Times(1)
+	mockTime.EXPECT().CurrentTime().Return(curTime).Times(2)
 	dcw := MakeDynamoCachedWatchDB(mockDB, mockTime)
 
 	// Query the data 3 hours after load
-	mockTime.EXPECT().CurrentTime().Return(curTime.Add(time.Hour * 3)).Times(2)
+	mockTime.EXPECT().CurrentTime().Return(curTime.Add(time.Hour * 3)).Times(3)
 	mockDB.EXPECT().GetTableScan().Return(makeFakeData()).Times(1)
 	watchPos, exists := dcw.GetWatchPosition("00000000-0000-0000-0000-000000000001")
 


### PR DESCRIPTION
Add locks to ensure each cached watch database only performs one read when necessary. Move mocks to the same package as the interface that they implement.